### PR TITLE
fixed a crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ def main():
         try:
             status = int(select('', 'HOME'))
         except:
-            status = int(select('', 'HOME'))
+            continue
             
         if status == 0:
             bye()


### PR DESCRIPTION
if you press "enter" twice with no input to the selection menu, the program throws an exception. This change prevents that from happening.